### PR TITLE
Update manifest to version 3, change getHostname to return 'host'

### DIFF
--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -12,7 +12,7 @@ function getHostname(url) {
 	if (/^chrome:\/\//.test(url)) { return; }
 	try {
 		var newUrl = new URL(url);
-		return newUrl.hostname;
+		return newUrl.host;
 	} catch (err) {
 		console.log(err);
 	}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,17 +1,17 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "Copy Host",
   "short_name": "copyhost",
   "description": "This extension allows you to copy hostname of the current tab to your clipboard.",
   "version": "1.0",
 
-  "browser_action": {
+  "action": {
     "default_icon": "img/icon16.png",
     "default_title": "Press the button to copy the hostname to the clipboard",
     "default_popup": "popup.html"
-  },  
-  "icons": { 
+  },
+  "icons": {
     "16": "img/icon16.png",
     "48": "img/icon48.png",
     "128": "img/icon128.png"
@@ -19,6 +19,9 @@
 
   "permissions": [
     "activeTab"
+  ],
+  "host_permissions": [
+    "*://*/*"
   ],
   "commands": {
     "_execute_browser_action": {

--- a/src/popup.html
+++ b/src/popup.html
@@ -8,6 +8,6 @@
 <body>
 	<div class="emoji">&#128588;</div>
 	<div id="hostname"></div>
-	<p>Copied to your clipboard </p>
+	<p>Copied to your clipboard</p>
 </body>
 </html>


### PR DESCRIPTION
- Updates manifest to version 3
- Changes getHostname function to return host property instead of hostname, this includes the port number if present in the URL